### PR TITLE
Add brainstorming high level design docs

### DIFF
--- a/docs/brainstorming/ai-agents.md
+++ b/docs/brainstorming/ai-agents.md
@@ -1,0 +1,35 @@
+# AI Agent Integration
+
+Forge can work with AI-powered services to enrich generation capabilities. Possible roles:
+
+- **Schema Synthesis** – propose data models or service endpoints based on textual descriptions.
+- **Code Suggestion** – fill in function bodies or offer test case scaffolds.
+- **Review/Refinement** – provide feedback and improvements on generated code before finalization.
+
+## Example Interaction Flow
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant Forge as Generation Service
+    participant Agent as AI Agent
+
+    Dev->>Forge: define service and data requirements
+    Forge->>Agent: ask for schema suggestions
+    Agent-->>Forge: returns candidate schema
+    Forge->>Agent: request code snippet for endpoint
+    Agent-->>Forge: sends code snippet
+    Forge->>Dev: present generated files
+```
+
+## Pseudocode Snippet
+
+```python
+from forge.agents import ChatAgent
+from forge.templates import ServiceTemplate
+
+agent = ChatAgent(model="gpt-4")
+proposal = agent.propose_schema(description="todo list api")
+service = ServiceTemplate(name="todo", schema=proposal)
+service.write_to("generated/todo_service")
+```

--- a/docs/brainstorming/architecture.md
+++ b/docs/brainstorming/architecture.md
@@ -1,0 +1,34 @@
+# High Level Architecture Ideas
+
+## Domain Driven Design Approach
+
+Forge can be structured around Domain Driven Design (DDD) concepts:
+
+- **Core Domain** – responsible for the fundamental building blocks of code generation: schema modelling, artifact definitions and templates.
+- **Application Layer** – orchestrates code generation workflows, interacts with AI agents, and applies domain services.
+- **Infrastructure Layer** – file system interactions, external tools and runtime environment management.
+
+### Conceptual Component Diagram
+
+```mermaid
+flowchart TD
+    subgraph Application Layer
+        A[CLI / API] --> B(Generation Service)
+        B --> C(AI Agent Gateway)
+        B --> D(Template Engine)
+    end
+    subgraph Core Domain
+        D -.-> E[Artifact Templates]
+        B -.-> F[Domain Models]
+    end
+    subgraph Infrastructure
+        C --> G[LLM Provider]
+        D --> H[Filesystem]
+    end
+```
+
+### Key Principles
+
+1. **Separation of Concerns** – keep generation logic isolated from infrastructure and UI concerns.
+2. **Extensibility** – provide plug points for new AI agents, templates, or generators.
+3. **Idempotency** – generating code multiple times should produce consistent results, avoiding overwriting manual edits.

--- a/docs/brainstorming/code-generation.md
+++ b/docs/brainstorming/code-generation.md
@@ -1,0 +1,42 @@
+# Code Generation Process
+
+The generation workflow could involve several stages:
+
+1. **Input Gathering** – The user specifies requirements via CLI, API, or configuration file.
+2. **Schema Creation** – Forge or an AI agent proposes a schema (data models, service endpoints, etc.).
+3. **Template Selection** – Based on the schema, appropriate templates are chosen.
+4. **Artifact Rendering** – Templates are filled with schema details and agent-generated snippets.
+5. **Post-Processing** – Formatting and linting, plus optional human review.
+
+```mermaid
+flowchart LR
+    A[User Input] --> B[Schema]
+    B --> C[Template Engine]
+    C --> D[Artifacts]
+    D --> E[Formatting/Lint]
+```
+
+## Example Configuration (YAML)
+
+```yaml
+todo_service:
+  language: python
+  models:
+    - name: Task
+      fields:
+        - title: str
+        - completed: bool
+  endpoints:
+    - path: /tasks
+      method: GET
+```
+
+## Simplified Generator Snippet
+
+```python
+def generate_service(config):
+    models = parse_models(config)
+    templates = load_templates(language=config['language'])
+    for model in models:
+        render_model(model, templates['model'])
+```

--- a/docs/brainstorming/overview.md
+++ b/docs/brainstorming/overview.md
@@ -1,0 +1,5 @@
+# Forge Brainstorming Overview
+
+This directory collects a series of early high level designs (HLDs) for **Forge**, a code generation framework that may incorporate AI agents. The goal is to outline possible architectures, repository layout, and key design principles.
+
+These documents are exploratory and not final specifications. They attempt to sketch out approaches that could be evaluated and iterated upon.

--- a/docs/brainstorming/repo-structure.md
+++ b/docs/brainstorming/repo-structure.md
@@ -1,0 +1,20 @@
+# Possible Repository Layout
+
+Below is a proposed layout that separates core modules from extensions and keeps generated code out of version control.
+
+```text
+forge/
+├── src/               # core library code
+│   ├── forge/
+│   │   ├── domain/
+│   │   ├── app/
+│   │   └── infrastructure/
+│   └── cli.py
+├── agents/            # optional built-in AI agents
+├── templates/         # default templates
+├── examples/          # sample generation projects
+└── docs/
+    └── brainstorming/ # design notes (this directory)
+```
+
+**Generated** artifacts would live under a separate directory specified by the user (e.g., `generated/`), keeping them isolated from the framework's code.

--- a/docs/brainstorming/todo.md
+++ b/docs/brainstorming/todo.md
@@ -1,0 +1,25 @@
+# Project Plan (High Level)
+
+## 1. Gather Requirements
+- [ ] Interview potential users to capture common generation scenarios
+- [ ] Decide on initial target languages (e.g., Python, TypeScript)
+
+## 2. Domain Design
+- [ ] Model schema objects (entities, services)
+- [ ] Define template format and storage
+- [ ] Outline AI agent interfaces
+
+## 3. Minimal Prototype
+- [ ] CLI to read a config file and generate basic project skeleton
+- [ ] Integrate a simple AI agent mock for schema suggestions
+- [ ] Write example templates for a REST API service
+
+## 4. Infrastructure
+- [ ] Establish directory layout (see `repo-structure.md`)
+- [ ] Add linting/formatting tools
+- [ ] Setup automated tests (unit + integration)
+
+## 5. Iterative Improvements
+- [ ] Improve agent integration with more advanced prompts
+- [ ] Handle incremental regeneration without overwriting manual changes
+- [ ] Publish documentation and tutorials


### PR DESCRIPTION
## Summary
- create new `docs/brainstorming` folder
- add overview and architecture notes
- outline potential repo structure
- describe code generation flow with mermaid diagrams
- document possible AI agent integration
- provide a high level project plan in `todo.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aa2aebc908323a1f792952b65045d