### PR TITLE
Add CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-forge – generative factory.
+# Forge
+
+Forge is a generative factory for producing project scaffolding and boilerplate. It is under heavy design and currently consists of brainstorming documents and prototypes.
+
+See [docs/cli.md](docs/cli.md) for the planned command line interface.

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # Interface Integration TODO
 
 ## 1. Define Interaction Modes
-- [ ] Document CLI entry points for direct user access.
+- [x] Document CLI entry points for direct user access.
 - [ ] Design REST API for service mode and remote callers.
 - [ ] Outline event bus semantics for Crucible communication.
 - [ ] Specify how Vault exposes read-only artifacts to Forge.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,15 @@
+# Forge CLI Overview
+
+The Forge command line interface allows developers to drive code generation workflows directly from the terminal. The CLI is designed around a few simple subcommands that mirror common tasks.
+
+## Entry Points
+
+- `forge init` – create a new project directory with a basic configuration file.
+- `forge generate` – run generators using the configuration in the current project.
+- `forge templates` – list the templates bundled with Forge.
+- `forge agents` – list available AI agents that can assist in generation.
+- `forge help` – show detailed usage information for any subcommand.
+
+Each command accepts `-h`/`--help` for additional options. The `generate` subcommand will read the project's configuration file (typically `forge.yml`) and produce code artifacts in the designated output directory.
+
+This interface is intentionally minimal so that additional protocols (REST, event bus) can reuse the same orchestrator logic underneath.


### PR DESCRIPTION
## Summary
- document planned CLI entry points
- update README to reference CLI documentation
- mark TODO item about documenting the CLI as complete

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686abff267108323831281f32233cba9