### PR TITLE
feat: design rest api (staff-grade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 Forge is a generative factory for producing project scaffolding and boilerplate. It is under heavy design and currently consists of brainstorming documents and prototypes.
 
-See [docs/cli.md](docs/cli.md) for the planned command line interface.
+See [docs/cli.md](docs/cli.md) for the planned command line interface. The
+service-mode REST API is outlined in
+[docs/design-rest-api.md](docs/design-rest-api.md).

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## 1. Define Interaction Modes
 - [x] Document CLI entry points for direct user access.
-- [ ] Design REST API for service mode and remote callers.
+- [x] Design REST API for service mode and remote callers.
 - [ ] Outline event bus semantics for Crucible communication.
 - [ ] Specify how Vault exposes read-only artifacts to Forge.
 

--- a/docs/design-rest-api.md
+++ b/docs/design-rest-api.md
@@ -1,0 +1,63 @@
+# Forge REST API Design
+
+This document outlines the REST interface for running Forge in **service mode**. The API allows remote callers to trigger generation workflows and inspect available templates.
+
+## Rationale
+
+Providing a small REST layer lets external tools drive Forge without relying on
+the CLI. It reuses the orchestrator so that behavior stays consistent across
+protocols.
+
+## Trade-offs
+
+- Adds an HTTP server dependency when used.
+- Network latency makes synchronous generation less desirable for large jobs;
+  an asynchronous job model keeps the API responsive.
+
+## Principles
+
+- **Simple HTTP semantics** – JSON request/response, predictable status codes.
+- **Same orchestration core** – the REST service uses the same command handlers as the CLI.
+- **Read-only by default** – generation results are immutable once produced.
+
+## Base URL
+
+All endpoints are served under `/api/v1/`.
+
+## Endpoints
+
+### `GET /health`
+Returns `200 OK` when the service is running.
+
+### `POST /generate`
+Submit a generation request.
+
+```json
+{
+  "template": "service-python",
+  "parameters": {"name": "demo"}
+}
+```
+
+Response contains a job identifier and initial status.
+
+### `GET /jobs/{id}`
+Retrieve the status and resulting artifacts for a generation job.
+
+### `GET /templates`
+List available templates with basic metadata.
+
+### `GET /templates/{name}`
+Return details for a single template, such as required parameters.
+
+## Error Handling
+
+- `400 Bad Request` for malformed input.
+- `404 Not Found` when a job or template does not exist.
+- `5xx` codes for server errors.
+
+## Future Extensions
+
+- WebSocket or SSE streaming for real-time job updates.
+- Authentication via API tokens when deployed in multi-user environments.
+


### PR DESCRIPTION
## Summary
- document REST API endpoints in `docs/design-rest-api.md`
- reference the design from the README
- mark API design task complete in TODO

## Design Rationale
The API exposes simple HTTP endpoints to trigger Forge generation and
query templates. Remote callers can drive the same orchestrator used by the
CLI while keeping operations read‑only. Job-based requests avoid long blocking
sessions.

## Risks
- Minimal; repository currently contains no code.

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`
- `pre-commit run --all-files` *(fails: `.pre-commit-config.yaml is not a file`)*

------
https://chatgpt.com/codex/tasks/task_e_686ac4ca1a048323b2afb55c1987ce53