### PR TITLE
feat: document event bus semantics (staff-grade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ Forge is a generative factory for producing project scaffolding and boilerplate.
 
 See [docs/cli.md](docs/cli.md) for the planned command line interface. The
 service-mode REST API is outlined in
-[docs/design-rest-api.md](docs/design-rest-api.md).
+[docs/design-rest-api.md](docs/design-rest-api.md). Communication with
+Crucible via an event bus is described in
+[docs/design-event-bus.md](docs/design-event-bus.md).

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 ## 1. Define Interaction Modes
 - [x] Document CLI entry points for direct user access.
 - [x] Design REST API for service mode and remote callers.
-- [ ] Outline event bus semantics for Crucible communication.
+ - [x] Outline event bus semantics for Crucible communication.
 - [ ] Specify how Vault exposes read-only artifacts to Forge.
 
 ## 2. Build Forge Orchestrator

--- a/docs/design-event-bus.md
+++ b/docs/design-event-bus.md
@@ -1,0 +1,51 @@
+# Forge Event Bus Semantics
+
+This document outlines how Forge communicates with **Crucible** or other tools via an event bus. The goal is to keep messages simple and transport agnostic so that various brokers (Redis, NATS, etc.) can be used.
+
+## Rationale
+
+An event bus enables loosely coupled interactions. Crucible can emit prompts or generation requests without knowing whether Forge is running locally or as a remote service. Forge publishes job status and artifacts back onto the bus for any interested consumer.
+
+## Message Format
+
+- JSON payloads encoded as UTF-8.
+- Each message contains a `type` field and a `payload` object.
+- Message envelopes may include broker-specific metadata (e.g., routing keys) but are not required by Forge.
+
+Example:
+
+```json
+{
+  "type": "forge.generate.request",
+  "payload": {
+    "template": "service-python",
+    "parameters": {"name": "demo"}
+  }
+}
+```
+
+## Channels
+
+### `forge.generate.request`
+Crucible publishes this to request a new generation job. Forge responds by creating a job and emitting `forge.generate.started` followed by progress events.
+
+### `forge.generate.started`
+Published by Forge when it accepts a request. Payload contains the job identifier.
+
+### `forge.generate.progress`
+Optional periodic updates with a percentage or stage label. Payload includes the job identifier and progress data.
+
+### `forge.generate.complete`
+Emitted when a job finishes successfully. Payload contains the job identifier and references to generated artifacts.
+
+### `forge.generate.error`
+Published if a job fails. Payload includes the job identifier and error message.
+
+## Acknowledgement
+
+Brokers that support acknowledgements (e.g., AMQP) should use "at least once" delivery. Forge components must be idempotent so that re-delivery does not corrupt state.
+
+## Future Extensions
+
+- Schema discovery requests (`forge.schema.query`) so Crucible can fetch valid input schemas.
+- Streaming logs or agent conversations over a dedicated channel.


### PR DESCRIPTION
## Summary
- outline event bus semantics for Crucible
- reference the new design doc in the README
- mark the TODO item as complete

## Design Rationale
`docs/design-event-bus.md` describes message formats and channels so future work on the orchestrator and repository integration can use consistent terminology. The design favors broker-agnostic JSON messages to keep things simple and portable.

## Risks
- none; documentation only.

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686acaf680408323b7a3d653f7d99165