### PR TITLE
feat: document vault readonly access (staff-grade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ See [docs/cli.md](docs/cli.md) for the planned command line interface. The
 service-mode REST API is outlined in
 [docs/design-rest-api.md](docs/design-rest-api.md). Communication with
 Crucible via an event bus is described in
-[docs/design-event-bus.md](docs/design-event-bus.md).
+[docs/design-event-bus.md](docs/design-event-bus.md). Vault's read-only
+artifact interface is covered in
+[docs/design-vault-readonly.md](docs/design-vault-readonly.md).

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 - [x] Document CLI entry points for direct user access.
 - [x] Design REST API for service mode and remote callers.
  - [x] Outline event bus semantics for Crucible communication.
-- [ ] Specify how Vault exposes read-only artifacts to Forge.
+ - [x] Specify how Vault exposes read-only artifacts to Forge.
 
 ## 2. Build Forge Orchestrator
 - [ ] Implement core controller accepting commands from multiple protocols.

--- a/docs/design-vault-readonly.md
+++ b/docs/design-vault-readonly.md
@@ -1,0 +1,44 @@
+# Vault Read-only Access Design
+
+This brief documents how Forge consumes artifacts stored in **Vault**. Vault is a versioned repository that stores templates and generation outputs for long term reuse. Forge needs a simple, read-only interface so that the same code can run locally or in service mode without embedding storage logic.
+
+## Rationale
+
+- **Consistency** – Forge should reference artifacts through stable identifiers regardless of storage backend.
+- **Safety** – Generation results must be immutable once written to Vault to prevent accidental overwrites.
+- **Simplicity** – A small HTTP API keeps dependencies light and works on developer laptops and in containers.
+
+## Proposed Interface
+
+Vault exposes artifacts over HTTP under a configurable base URL. Forge retrieves artifacts using standard `GET` requests:
+
+```
+GET /api/v1/artifacts/{id}
+```
+
+Responses include metadata and a download URL for the immutable content:
+
+```json
+{
+  "id": "svc-python-v1",
+  "filename": "service-python.zip",
+  "sha256": "...",
+  "download_url": "/api/v1/artifacts/svc-python-v1/file"
+}
+```
+
+Artifacts are served as read-only blobs; Vault denies `PUT` or `DELETE` on these paths. Clients may optionally list available artifacts:
+
+```
+GET /api/v1/artifacts
+```
+
+Forge only needs read access, so authentication (if any) uses a token with download-only permissions.
+
+## Usage in Forge
+
+1. The orchestrator resolves artifact IDs from templates or job records.
+2. It constructs the full URL using `VAULT_BASE_URL` (default `http://localhost:8000`).
+3. Artifacts are fetched with `GET`. Forge unpacks archives into a working directory but never writes back to Vault.
+
+This design keeps Forge agnostic of the storage implementation while ensuring artifacts remain immutable.


### PR DESCRIPTION
## Summary
- design how Forge reads artifacts from Vault via HTTP
- reference the new design in the README
- mark the Vault access task complete in TODO

## Design Rationale
See `docs/design-vault-readonly.md` for details on the minimal HTTP interface and usage pattern. The goal is to keep Forge storage-agnostic while ensuring artifacts remain immutable.

## Risks
- This documentation may diverge from future Vault implementations if API details change.

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ad75a1e388323a2d4770cc17dd9ed