### PR TITLE
feat: initial orchestrator (staff-grade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Forge
 
-Forge is a generative factory for producing project scaffolding and boilerplate. It is under heavy design and currently consists of brainstorming documents and prototypes.
+Forge is a generative factory for producing project scaffolding and boilerplate.
+It is under heavy design and currently consists of brainstorming documents and
+prototypes. The heart of Forge is the **orchestrator**, a small controller that
+dispatches commands from the CLI, REST API or an event bus to registered
+handlers. Each protocol submits `Command` objects so that generation logic stays
+consistent regardless of how a request arrives.
 
 See [docs/cli.md](docs/cli.md) for the planned command line interface. The
 service-mode REST API is outlined in
@@ -9,3 +14,15 @@ Crucible via an event bus is described in
 [docs/design-event-bus.md](docs/design-event-bus.md). Vault's read-only
 artifact interface is covered in
 [docs/design-vault-readonly.md](docs/design-vault-readonly.md).
+
+```python
+from forge.orchestrator import Command, Orchestrator
+
+orch = Orchestrator()
+
+def init_project(payload: dict) -> dict:
+    return {"created": payload["name"]}
+
+orch.register("init", init_project)
+result = orch.handle(Command(source="cli", name="init", payload={"name": "demo"}))
+```

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
  - [x] Specify how Vault exposes read-only artifacts to Forge.
 
 ## 2. Build Forge Orchestrator
-- [ ] Implement core controller accepting commands from multiple protocols.
+- [x] Implement core controller accepting commands from multiple protocols.
 - [ ] Provide adapters for CLI, REST, and event bus messages.
 - [ ] Support manual (human) control via MCP or similar channels.
 

--- a/docs/design-controller.md
+++ b/docs/design-controller.md
@@ -1,0 +1,36 @@
+# Orchestrator Core Controller Design
+
+## Rationale
+The orchestrator coordinates code generation regardless of whether a request
+comes from the CLI, REST API or an event bus. A single controller keeps logic
+consistent across these protocols while keeping the surface area small.
+
+## Approach
+* Represent each incoming command with a simple dataclass containing `source`,
+  `name` and a `payload` dictionary.
+* The `Orchestrator` stores a mapping of command names to handler functions.
+* Adapters for the CLI, REST or event bus create `Command` objects and pass them
+to `Orchestrator.handle()`.
+* Handlers are plain callables returning a result dictionary. No protocol
+  details are exposed to handlers.
+
+```
+CLI/REST/bus -> Command -> Orchestrator -> handler -> result
+```
+
+## Alternatives Considered
+* Using a command class hierarchy – rejected as over-engineering for the small
+  set of actions currently planned.
+* Embedding protocol logic in handlers – makes testing and reuse harder and
+  complicates future extensions.
+
+## Trade-offs
+* The orchestrator is synchronous; async adapters can wrap it if needed.
+* Duplicate command names raise an error to avoid accidental overrides.
+
+## Affected Modules
+* `forge/orchestrator.py` – new module implementing `Command` and
+  `Orchestrator`.
+* `tests/test_orchestrator.py` – unit tests for registration and dispatch
+  behavior.
+

--- a/forge/orchestrator.py
+++ b/forge/orchestrator.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Mapping
+
+
+@dataclass(slots=True)
+class Command:
+    """A request from a specific protocol."""
+
+    source: str
+    name: str
+    payload: Mapping[str, Any]
+
+
+Handler = Callable[[Mapping[str, Any]], Mapping[str, Any] | None]
+
+
+class Orchestrator:
+    """Dispatch commands to registered handlers."""
+
+    def __init__(self) -> None:
+        self._handlers: Dict[str, Handler] = {}
+
+    def register(self, name: str, handler: Handler) -> None:
+        if name in self._handlers:
+            raise ValueError(f"handler already registered for '{name}'")
+        self._handlers[name] = handler
+
+    def handle(self, command: Command) -> Mapping[str, Any] | None:
+        try:
+            handler = self._handlers[command.name]
+        except KeyError as exc:
+            raise ValueError(f"no handler for '{command.name}'") from exc
+        return handler(command.payload)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from forge.orchestrator import Command, Orchestrator
+
+
+def test_register_and_handle() -> None:
+    orch = Orchestrator()
+
+    def echo(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {"echo": dict(payload)}
+
+    orch.register("echo", echo)
+    result = orch.handle(Command(source="cli", name="echo", payload={"a": 1}))
+    assert result == {"echo": {"a": 1}}
+
+
+def test_unknown_command() -> None:
+    orch = Orchestrator()
+    try:
+        orch.handle(Command(source="cli", name="missing", payload={}))
+    except ValueError as e:
+        assert "no handler" in str(e)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_duplicate_registration() -> None:
+    orch = Orchestrator()
+
+    def handler(_: Mapping[str, Any]) -> None:
+        return None
+
+    orch.register("dup", handler)
+    try:
+        orch.register("dup", handler)
+    except ValueError as e:
+        assert "already" in str(e)
+    else:
+        raise AssertionError("expected ValueError")


### PR DESCRIPTION
## Summary
- design orchestrator controller
- implement `Orchestrator` and `Command`
- document orchestrator usage in README
- add unit tests
- mark TODO item complete

## Design Rationale
See `docs/design-controller.md` for the approach and trade-offs.

## Risks
- minimal: no external dependencies, pure Python
- pre-commit not configured; command fails

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`
- `pre-commit run --all-files` *(fails: `.pre-commit-config.yaml` is missing)*

------
https://chatgpt.com/codex/tasks/task_e_686afaf4f8108323865f5e8b37cdcb05